### PR TITLE
Fix run-to-run reproducibility

### DIFF
--- a/diffacto/diffacto.py
+++ b/diffacto/diffacto.py
@@ -599,7 +599,7 @@ def main():
             continue
         # =====----=====-----=====-----=====
         peps = pg[prot]  # constituent peptides
-        dx = df.ix[[p for p in peps if p in df.index]]  # dataframe
+        dx = df.ix[[p for p in sorted(peps) if p in df.index]]  # dataframe
         pep_count = len(dx)  # number of peptides
         pep_abd = dx[samples].values
 


### PR DESCRIPTION
It seems like I've found and fixed the problem of run-to-run reproducibility issue #4 . Now output files are always the same from run to run with same parameters.

Regards,
Mark