### PR TITLE
Fix problems where a peptide has only one non-missing value

### DIFF
--- a/diffacto/diffacto.py
+++ b/diffacto/diffacto.py
@@ -588,7 +588,7 @@ def main():
         df = df[[len(pep2prot[p]) == 1 for p in df.index]]
 
     #Check that we don't have any peptides with a single non-missing value. These tend to break diffacto, because in fast_farms we end up with a covariance matrix of less than full rank. Which the algorithm is not set up to handle.
-    nonZeroNonMissing = np.vectorize(lambda x : ~np.isnan(x) and x > 0, otypes = np.bool)
+    nonZeroNonMissing = np.vectorize(lambda x : ~np.isnan(x) and x > 0, otypes = [np.bool])
     if df.shape[0] > 0:
         for prot in sorted(pg.keys()):
             if prot == 'nan':

--- a/diffacto/diffacto.py
+++ b/diffacto/diffacto.py
@@ -588,21 +588,22 @@ def main():
         df = df[[len(pep2prot[p]) == 1 for p in df.index]]
 
     #Check that we don't have any peptides with a single non-missing value. These tend to break diffacto, because in fast_farms we end up with a covariance matrix of less than full rank. Which the algorithm is not set up to handle.
-    nonZeroNonMissing = np.vectorize(lambda x : ~np.isnan(x) and x > 0)
-    for prot in sorted(pg.keys()):
-        if prot == 'nan':
-            continue
-        if DEBUG and EXAMPLE not in prot:
-            continue
-        # =====----=====-----=====-----=====
-        peps = pg[prot]  # constituent peptides
-        dx = df.ix[[p for p in sorted(peps) if p in df.index]]  # dataframe
-        pep_count = len(dx)  # number of peptides
-        pep_abd = dx[samples].values
-        counts = np.sum(nonZeroNonMissing(pep_abd), axis = 1)
-        if any(counts < 2):
-            print("Protein {} contained peptides with fewer than two non-missing or non-zero values. Please remove these peptides".format(prot))
-            return
+    nonZeroNonMissing = np.vectorize(lambda x : ~np.isnan(x) and x > 0, otypes = np.bool)
+    if df.shape[0] > 0:
+        for prot in sorted(pg.keys()):
+            if prot == 'nan':
+                continue
+            if DEBUG and EXAMPLE not in prot:
+                continue
+            # =====----=====-----=====-----=====
+            peps = pg[prot]  # constituent peptides
+            dx = df.ix[[p for p in sorted(peps) if p in df.index]]  # dataframe
+            pep_count = len(dx)  # number of peptides
+            pep_abd = dx[samples].values
+            counts = np.sum(nonZeroNonMissing(pep_abd), axis = 1)
+            if any(counts < 2):
+                print("Protein {} contained peptides with fewer than two non-missing or non-zero values. Please remove these peptides".format(prot))
+                return
 
     # -------------------------------------------------------------------------
     # perform differential analysis


### PR DESCRIPTION
Fix problems where a peptide has only one non-missing value, by giving an error at the very start. 

If you don't explicitly handle this case, the internal factor analysis code tends to break. The process that causes this to happen is:
- Data is median normalized. So if there is a single non-missing value, that non-missing value becomes 0. Then NaNs are replaced with zeros.
- This means that after normalization, if there is only one non-missing value for a peptide, the values for that peptide will be all zeros, at least in the form input to the factor analysis.
- In the factor analysis, there is a correlation matrix calculated. If one of the input peptides is always zero, one of the diagonal entries in the correlation matrix will be zero, rather than one.
- This means the correlation matrix is not of full rank. The code does not seem to be set up for this case.
- Returning an error seems reasonable. You lose nothing by excluding peptides with a single non-missing value. 