### PR TITLE
Change obsolete connected_component_subgraphs call to connected_components

### DIFF
--- a/diffacto/diffacto.py
+++ b/diffacto/diffacto.py
@@ -260,7 +260,7 @@ def parsimony_grouping(g, peps):
     """
     not_peps = set(g.nodes()) - set(peps)
     prot_groups = dict()
-    for cc in nx.connected_component_subgraphs(g):
+    for cc in (g.subgraph(c).copy() for c in nx.connected_components(g)):
         in_group_peptides = set(cc.nodes()) - not_peps
         in_group_proteins = not_peps.intersection(cc.nodes())
 


### PR DESCRIPTION
Diffacto errors out on my machine with networkx 2.4 because the `connected_component_subgraphs()` function appears to have been removed ([changelog](https://networkx.github.io/documentation/stable/release/release_2.4.html) says it has been deprecated since 2.1). The [doc](https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.connected_components.html) says we should use:
`S = [G.subgraph(c).copy() for c in connected_components(G)]`
to get subgraphs, which is what I added.
