### PR TITLE
Fix dtype spec for compatibility with latest numpy versions

### DIFF
--- a/diffacto/diffacto.py
+++ b/diffacto/diffacto.py
@@ -732,7 +732,7 @@ def main():
     # Check that we don't have any peptides with a single non-missing value.
     # These tend to break diffacto, because in fast_farms we end up with a covariance matrix of less than full rank. Which the algorithm is not set up to handle.
     nonZeroNonMissing = np.vectorize(
-        lambda x: ~np.isnan(x) and x != 0, otypes=[np.bool]
+        lambda x: ~np.isnan(x) and x != 0, otypes=[np.bool_]
     )
     if df.shape[0] > 0:
         for prot in sorted(pg.keys()):


### PR DESCRIPTION
Since NumPy 1.20, the use of `np.bool` was deprecated, and in 1.24, it was [removed](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations). While it is going to return in the future, currently an error occurs when `np.bool` is used with NumPy 1.24 to 1.26 (current latest version).
This PR changes it to `np.bool_` which should work on new and older versions.